### PR TITLE
Adds JOSM Remote Control link

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,8 @@
 
-const url_prefix = "tms:https://heatmap-external-{switch:a,b,c}.strava.com/tiles-auth/";
+const url_prefix = "https://heatmap-external-{switch:a,b,c}.strava.com/tiles-auth/";
 const url_suffix = "/{zoom}/{x}/{y}.png"
 
-async function getHeatmapUrl(map_color, map_type, tab_url, store_id) 
+async function getHeatmapUrl(map_color, map_type, tab_url, store_id)
 {
     let pair = await getCookieValue('CloudFront-Key-Pair-Id', tab_url, store_id);
     let policy = await getCookieValue('CloudFront-Policy', tab_url, store_id);
@@ -28,7 +28,7 @@ async function getCookieValue(name, url, store_id)
 browser.runtime.onMessage.addListener(async function (message, sender, sendResponse) {
     return getHeatmapUrl(
         message.map_color,
-        message.map_type, 
+        message.map_type,
         sender.tab.url,
         sender.tab.cookieStoreId
     )

--- a/content.css
+++ b/content.css
@@ -49,13 +49,14 @@ button.josm-imagery {
 }
 .josm-modal-dialog menu li {
     list-style: none;
+    margin-bottom: 7px;
+}
+.josm-modal-dialog .btn {
+    font-size: 16px;
 }
 .josm-modal-dialog .copy-button {
     position: absolute;
-    /* padding: 6px; */
     right: 8px;
     top: 8px;
-    /* vertical-align: middle;
-    text-align: center; */
     background-color: transparent;
 }

--- a/content.css
+++ b/content.css
@@ -34,12 +34,28 @@ button.josm-imagery {
 .josm-modal-dialog code {
     background-color: lightgray;
     border-radius: 3px;
-    padding: 10px;
+    padding: 10px 50px 10px 10px;
     display: block;
+    position: relative;
 }
 .josm-modal-dialog pre {
     margin: 0;
     white-space: pre-wrap;
     word-wrap: break-word;
     word-break: break-all;
+}
+.josm-modal-dialog menu {
+    padding-inline-start: 0px;
+}
+.josm-modal-dialog menu li {
+    list-style: none;
+}
+.josm-modal-dialog .copy-button {
+    position: absolute;
+    /* padding: 6px; */
+    right: 8px;
+    top: 8px;
+    /* vertical-align: middle;
+    text-align: center; */
+    background-color: transparent;
 }

--- a/content.js
+++ b/content.js
@@ -10,22 +10,24 @@ function insertModal()
                 <div class="modal-header">
                     <h4 id="josm-modal-message"></h5>
                 </div>
-                <menu id="imagery-load-menu">
-                    <li>
-                        <a class="btn btn-xs btn-default" id="josm-click-to-load">Click to open imagery in JOSM</a>
-                    </li>
-                    <li>Or, manually copy the URL and paste into JOSM imagery preferences:
-                        <code>
-                            <button id="josm-click-to-copy" class="copy-button btn btn-xs" aria-label="Copy to clipboard" title="Copy to clipboard">
-                                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
-                                    <path d="M0 0h24v24H0V0z" fill="none" />
-                                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
-                                </svg>
-                            </button>
-                            <pre id="josm-imagery-url"></pre>
-                        </code>
-                    </li>
-                </menu>
+                <div class="modal-body">
+                    <menu id="imagery-load-menu">
+                        <li>
+                            <a class="btn btn-xs btn-default" id="josm-click-to-load">Open imagery in JOSM</a>
+                        </li>
+                        <li>Or, copy the URL and paste into JOSM imagery preferences:
+                            <code>
+                                <button id="josm-click-to-copy" class="copy-button btn btn-xs" aria-label="Copy to clipboard" title="Copy to clipboard">
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+                                        <path d="M0 0h24v24H0V0z" fill="none" />
+                                        <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+                                    </svg>
+                                </button>
+                                <pre id="josm-imagery-url"></pre>
+                            </code>
+                        </li>
+                    </menu>
+                </div>
             </div>
         </div>
     `);

--- a/content.js
+++ b/content.js
@@ -11,6 +11,9 @@ function insertModal()
                 <code>
                     <pre id="josm-imagery-url"></pre>
                 </code>
+                <p>
+                    <a id="josm-click-to-load">Click to open imagery in JOSM</a>
+                </p>
             </div>
         </div>
     `);
@@ -46,9 +49,13 @@ async function insertButton()
     button.addEventListener("click", copyHeatmapUrl);
 }
 
-async function copyHeatmapUrl(e) 
+async function copyHeatmapUrl(e)
 {
-    let response, message, heatmap_url;
+    let response,
+      message,
+      heatmap_url_manual_copy,
+      heatmap_url_click,
+      base_heatmap_url;
 
     let map_color = document.querySelector(".map-color.active").getAttribute("data-color");
     let map_type = document.querySelector(".map-type.active").getAttribute("data-type");
@@ -61,19 +68,24 @@ async function copyHeatmapUrl(e)
         });
         if (response.error) {
             message = "Error: missing cookies"
-            heatmap_url = "One or more cookies not found - 'CloudFront-Key-Pair-Id', 'CloudFront-Policy', 'CloudFront-Signature'"
+            heatmap_url_manual_copy = "One or more cookies not found - 'CloudFront-Key-Pair-Id', 'CloudFront-Policy', 'CloudFront-Signature'"
         } else {
-            heatmap_url = response.heatmap_url
-            navigator.clipboard.writeText(heatmap_url)
+            base_heatmap_url = response.heatmap_url;
+            heatmap_url_manual_copy = "tms:" + base_heatmap_url;
+            heatmap_url_click =
+              "http://127.0.0.1:8111/imagery?title=Strava&type=tms&max_zoom=15&url=" +
+              base_heatmap_url;
+            navigator.clipboard.writeText(heatmap_url_manual_copy);
             message = "JOSM imagery URL has been copied to the clipboard"
         }
     } catch(err) {
         console.log(err)
         message = "Unknown error - check console"
-        heatmap_url = "couldn't build url"
+        heatmap_url_manual_copy = "couldn't build url"
     }
-    
+
     document.querySelector('#josm-modal-message').textContent = message
-    document.querySelector('#josm-imagery-url').textContent = heatmap_url
+    document.querySelector('#josm-imagery-url').textContent = heatmap_url_manual_copy
+    document.querySelector("#josm-click-to-load").href = heatmap_url_click
     document.querySelector('#josm-modal').classList.add('active');
 }

--- a/content.js
+++ b/content.js
@@ -16,7 +16,7 @@ function insertModal()
                     </li>
                     <li>Or, manually copy the URL and paste into JOSM imagery preferences:
                         <code>
-                            <button class="copy-button btn btn-xs" onclick="" aria-label="Copy to clipboard" title="Copy to clipboard">
+                            <button id="josm-click-to-copy" class="copy-button btn btn-xs" aria-label="Copy to clipboard" title="Copy to clipboard">
                                 <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
                                     <path d="M0 0h24v24H0V0z" fill="none" />
                                     <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
@@ -58,10 +58,10 @@ async function insertButton()
         </svg>
     `
     ctrl_top_right.prepend(button);
-    button.addEventListener("click", copyHeatmapUrl);
+    button.addEventListener("click", openJosmDialog);
 }
 
-async function copyHeatmapUrl(e)
+async function openJosmDialog(e)
 {
     let response,
       message,
@@ -87,7 +87,6 @@ async function copyHeatmapUrl(e)
             heatmap_url_click =
               "http://127.0.0.1:8111/imagery?title=Strava&type=tms&max_zoom=15&url=" +
               base_heatmap_url;
-            navigator.clipboard.writeText(heatmap_url_manual_copy);
             message = "Open heatmap in editor"
         }
     } catch(err) {
@@ -100,4 +99,10 @@ async function copyHeatmapUrl(e)
     document.querySelector('#josm-imagery-url').textContent = heatmap_url_manual_copy
     document.querySelector("#josm-click-to-load").href = heatmap_url_click
     document.querySelector('#josm-modal').classList.add('active');
+    document.querySelector("#josm-click-to-copy").addEventListener("click", copyUrlToClipboard);
+}
+
+function copyUrlToClipboard() {
+    let heatmapUrlManualCopy = document.querySelector("#josm-imagery-url").innerHTML;
+    navigator.clipboard.writeText(heatmapUrlManualCopy);
 }

--- a/content.js
+++ b/content.js
@@ -103,6 +103,6 @@ async function openJosmDialog(e)
 }
 
 function copyUrlToClipboard() {
-    let heatmapUrlManualCopy = document.querySelector("#josm-imagery-url").innerHTML;
-    navigator.clipboard.writeText(heatmapUrlManualCopy);
+    let heatmap_url_manual_copy = document.querySelector("#josm-imagery-url").innerHTML;
+    navigator.clipboard.writeText(heatmap_url_manual_copy);
 }

--- a/content.js
+++ b/content.js
@@ -7,13 +7,25 @@ function insertModal()
     document.body.insertAdjacentHTML('afterbegin', `
         <div id="josm-modal" class="josm-modal">
             <div id="josm-modal-dialog" class="josm-modal-dialog">
-                <h5 id="josm-modal-message"></h5>
-                <code>
-                    <pre id="josm-imagery-url"></pre>
-                </code>
-                <p>
-                    <a id="josm-click-to-load">Click to open imagery in JOSM</a>
-                </p>
+                <div class="modal-header">
+                    <h4 id="josm-modal-message"></h5>
+                </div>
+                <menu id="imagery-load-menu">
+                    <li>
+                        <a class="btn btn-xs btn-default" id="josm-click-to-load">Click to open imagery in JOSM</a>
+                    </li>
+                    <li>Or, manually copy the URL and paste into JOSM imagery preferences:
+                        <code>
+                            <button class="copy-button btn btn-xs" onclick="" aria-label="Copy to clipboard" title="Copy to clipboard">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+                                    <path d="M0 0h24v24H0V0z" fill="none" />
+                                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+                                </svg>
+                            </button>
+                            <pre id="josm-imagery-url"></pre>
+                        </code>
+                    </li>
+                </menu>
             </div>
         </div>
     `);
@@ -76,7 +88,7 @@ async function copyHeatmapUrl(e)
               "http://127.0.0.1:8111/imagery?title=Strava&type=tms&max_zoom=15&url=" +
               base_heatmap_url;
             navigator.clipboard.writeText(heatmap_url_manual_copy);
-            message = "JOSM imagery URL has been copied to the clipboard"
+            message = "Open heatmap in editor"
         }
     } catch(err) {
         console.log(err)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "JOSM Strava Heatmap",
   "description": "A browser extension that simplifies getting the TMS imagery url for using the Strava Heatmap in JOSM",
-  "version": "3",
+  "version": "4",
   "icons": {
     "48": "icons/icon.png"
   },


### PR DESCRIPTION
This PR adds a one-click link to open the selected Strava layer in JOSM, via the remote control functionality. This only loads the imagery for the current session, and will not make the imagery appear in JOSM's Imagery menu.

I messed around a bunch with the way the URL is constructed internally, and am more than happy to make changes to this PR if there's a less-disruptive way to achieve the same result, and to incorporate feedback for better UX.