### PR TITLE
Fix plugin after it broke post-Strava MapLibre GL JS move.

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,7 +1,7 @@
 button.jsh-modal-toggle {
     position: fixed;
-    top: 80px;
-    right: 10px;
+    top: 130px;
+    right: 16px;
     z-index: 50;
     border: none;
     border-radius: 3px;

--- a/content.css
+++ b/content.css
@@ -1,9 +1,12 @@
 button.jsh-modal-toggle {
+    position: fixed;
+    top: 80px;
+    right: 10px;
+    z-index: 50;
     border: none;
     border-radius: 3px;
     width: 40px;
     height: 40px;
-    margin: 80px 10px 10px;
     padding: 0;
     background-color: white;
     /* background-image: url('icons/icon.svg'); */
@@ -14,10 +17,7 @@ button.jsh-modal-toggle {
 
 @media (max-width: 800px) {
     button.jsh-modal-toggle {
-        margin: 10px;
-    }
-    .mapboxgl-control-container > .mapboxgl-ctrl-top-right {
-        z-index: 50;
+        top: 60px;
     }
 }
 

--- a/content.js
+++ b/content.js
@@ -29,11 +29,11 @@ function insertModalHtml()
  */
 async function insertButtonHtml()
 {
-    let ctrl_top_right = document.querySelector('.mapboxgl-ctrl-top-right');
-    // Sometimes the mapbox controls aren't loaded right away and we need to wait a little bit
-    for (let i = 0; ctrl_top_right === null && i < 10; i++) {
-        await new Promise(r => setTimeout(r, 300));
-        ctrl_top_right = document.querySelector('.mapboxgl-ctrl-top-right');
+    // Anchored on <body> with position:fixed because injecting into Strava's React-rendered map tree gets wiped on re-render.
+    const selector = '[class*="Map_map__"], .maplibregl-ctrl-top-right, .mapboxgl-ctrl-top-right';
+    if (!(await waitForElement(selector, 15000))) {
+        console.error('[JOSM Strava Heatmap] Timed out waiting for map UI');
+        return;
     }
     let button = document.createElement('button');
     button.className = 'jsh-modal-toggle';
@@ -50,8 +50,24 @@ async function insertButtonHtml()
         <path d="M46 32.8H32.8V46H46zm-30.8 0H2V46h13.2zm15.4 0H17.4V46h13.2zm0-15.4H17.4v13.2h13.2zm-15.4 0H2v13.2h13.2zm30.8 0H32.8v13.2H46zM15.2 2H2v13.2h13.2zM46 2H32.8v13.2H46zM30.6 2H17.4v13.2h13.2z" fill="url(#b)"/>
         </svg>
     `;
-    ctrl_top_right.prepend(button);
+    document.body.appendChild(button);
     button.addEventListener("click", openModalDialog);
+}
+
+/** Resolve with the first match for `selector`, or `null` after `timeout_ms`. */
+function waitForElement(selector, timeout_ms)
+{
+    return new Promise(resolve => {
+        const existing = document.querySelector(selector);
+        if (existing) { resolve(existing); return; }
+        let timer;
+        const observer = new MutationObserver(() => {
+            const el = document.querySelector(selector);
+            if (el) { observer.disconnect(); clearTimeout(timer); resolve(el); }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        timer = setTimeout(() => { observer.disconnect(); resolve(null); }, timeout_ms);
+    });
 }
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # JOSM Strava Heatmap
 
-**NOTE:** This is simply a fork/clone of [zekefarwell/josm-strava-heatmap][11] that I ran through Claude Opus 4.7 to fix the extension not working after Strava switched map libraries.
+**NOTE:** This is simply a fork/clone of [zekefarwell/josm-strava-heatmap][11] that I ran through Claude Opus 4.7 to fix the extension not working after Strava switched map libraries. Issue was reported [here](https://github.com/zekefarwell/josm-strava-heatmap/issues/23).
 
 ----
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # JOSM Strava Heatmap
 
+**NOTE:** This is simply a fork/clone of [zekefarwell/josm-strava-heatmap][11] that I ran through Claude Opus 4.7 to fix the extension not working after Strava switched map libraries.
+
+----
+
 This browser extension makes it easy to use the [Strava Global Heatmap][1] in
 [JOSM][2].
 
@@ -21,6 +25,7 @@ OSM Wiki: [Using the Strava Heatmap][3]
 [3]: https://wiki.openstreetmap.org/wiki/Strava
 [8]: https://www.openstreetmap.org
 [10]: https://github.com/julcnx/strava-heatmap-extension
+[11]: https://github.com/zekefarwell/josm-strava-heatmap
 
 ## Installation
 


### PR DESCRIPTION
Fixes [issue 23](https://github.com/zekefarwell/josm-strava-heatmap/issues/23). Puts the icon in a bit different spot to not overlap other buttons.